### PR TITLE
Fix backslash bug in main models cache file

### DIFF
--- a/src/Ubiquity/cache/traits/ModelsCacheTrait.php
+++ b/src/Ubiquity/cache/traits/ModelsCacheTrait.php
@@ -73,7 +73,7 @@ trait ModelsCacheTrait {
 			}
 		}
 		if (! $forChecking) {
-			self::$cache->store ( 'models\_modelsDatabases', 'return ' . UArray::asPhpArray ( $modelsDb, 'array' ) . ';', 'models' );
+			self::$cache->store ( '_modelsDatabases', 'return ' . UArray::asPhpArray ( $modelsDb, 'array' ) . ';', 'models' );
 		}
 		if (! $silent) {
 			echo "Models cache reset\n";
@@ -138,8 +138,8 @@ trait ModelsCacheTrait {
 	}
 
 	public static function getModelsDatabases() {
-		if (self::$cache->exists ( 'models\_modelsDatabases' )) {
-			return self::$cache->fetch ( 'models\_modelsDatabases' );
+		if (self::$cache->exists ( '_modelsDatabases' )) {
+			return self::$cache->fetch ( '_modelsDatabases' );
 		}
 		return [ ];
 	}

--- a/src/Ubiquity/cache/traits/ModelsCacheTrait.php
+++ b/src/Ubiquity/cache/traits/ModelsCacheTrait.php
@@ -73,7 +73,7 @@ trait ModelsCacheTrait {
 			}
 		}
 		if (! $forChecking) {
-			self::$cache->store ( '_modelsDatabases', 'return ' . UArray::asPhpArray ( $modelsDb, 'array' ) . ';', 'models' );
+			self::$cache->store ( 'models/_modelsDatabases', 'return ' . UArray::asPhpArray ( $modelsDb, 'array' ) . ';', 'models' );
 		}
 		if (! $silent) {
 			echo "Models cache reset\n";
@@ -138,8 +138,8 @@ trait ModelsCacheTrait {
 	}
 
 	public static function getModelsDatabases() {
-		if (self::$cache->exists ( '_modelsDatabases' )) {
-			return self::$cache->fetch ( '_modelsDatabases' );
+		if (self::$cache->exists ( 'models/_modelsDatabases' )) {
+			return self::$cache->fetch ( 'models/_modelsDatabases' );
 		}
 		return [ ];
 	}


### PR DESCRIPTION
Please don't use a backslash in naming a file, this causes problems with file operations in IDE's like PhpStorm.
