### PR TITLE
Fixed doc on setVar

### DIFF
--- a/docs/controller/controllers.rst
+++ b/docs/controller/controllers.rst
@@ -170,7 +170,7 @@ Variables can also be passed before the view is loaded:
 .. code-block:: php
    
    //passing one variable
-   $this->view->setVar("title"=>"Message");
+   $this->view->setVar("title","Message");
    //passing an array of 2 variables
    $this->view->setVars(["message"=>$message,"recipient"=>$name]);
    //loading the view that now contains 3 variables


### PR DESCRIPTION
Changed from `$this->view->setVar("title"=>"Message");` to `$this->view->setVar("title","Message");`
Double arrow are for arrays
