### PR TITLE
Fixing trait method visibility

### DIFF
--- a/src/Ubiquity/controllers/Router.php
+++ b/src/Ubiquity/controllers/Router.php
@@ -112,10 +112,10 @@ class Router {
 	 * @return boolean|mixed[]|string
 	 */
 	public static function getRoute($path, $cachedResponse = true, $debug = false) {
-	    $index = $path;
-	    if (isset(self::$routesIndex[$index])) {
-	        return self::$routesIndex[$index];
-        }
+		$index = $path;
+		if (isset(self::$routesIndex[$index])) {
+			return self::$routesIndex[$index];
+		}
 
 		$path = self::slashPath ( $path );
 		if (isset ( self::$routes [$path] ) && ! $debug) { // No direct access to route in debug mode (for maintenance mode activation)

--- a/src/Ubiquity/controllers/Router.php
+++ b/src/Ubiquity/controllers/Router.php
@@ -21,6 +21,7 @@ use Ubiquity\utils\http\URequest;
 class Router {
 	use RouterModifierTrait,RouterAdminTrait,RouterTestTrait;
 	protected static $routes;
+	protected static $routesIndex;
 
 	private static function cleanParam(string $param): string {
 		if (\substr ( $param, - 1 ) === '/')
@@ -111,6 +112,11 @@ class Router {
 	 * @return boolean|mixed[]|string
 	 */
 	public static function getRoute($path, $cachedResponse = true, $debug = false) {
+	    $index = $path;
+	    if (isset(self::$routesIndex[$index])) {
+	        return self::$routesIndex[$index];
+        }
+
 		$path = self::slashPath ( $path );
 		if (isset ( self::$routes [$path] ) && ! $debug) { // No direct access to route in debug mode (for maintenance mode activation)
 			return self::getRoute_ ( self::$routes [$path], $path, [ $path ], $cachedResponse );
@@ -118,12 +124,12 @@ class Router {
 		foreach ( self::$routes as $routePath => $routeDetails ) {
 			if (\preg_match ( "@^{$routePath}\$@s", $path, $matches )) {
 				if (($r = self::getRoute_ ( $routeDetails, $routePath, $matches, $cachedResponse )) !== false) {
-					return $r;
+					return self::$routesIndex[$index] = $r;
 				}
 			}
 		}
 		Logger::warn ( 'Router', "No route found for {$path}", 'getRoute' );
-		return false;
+		return self::$routesIndex[$index] = false;
 	}
 
 	/**

--- a/src/Ubiquity/controllers/crud/CRUDControllerUtilitiesTrait.php
+++ b/src/Ubiquity/controllers/crud/CRUDControllerUtilitiesTrait.php
@@ -187,7 +187,7 @@ trait CRUDControllerUtilitiesTrait {
 		return new ModelViewer ( $this );
 	}
 
-	private function _getModelViewer(): ModelViewer {
+	public function _getModelViewer(): ModelViewer {
 		return $this->getSingleton ( $this->modelViewer, "getModelViewer" );
 	}
 

--- a/src/Ubiquity/controllers/crud/CRUDControllerUtilitiesTrait.php
+++ b/src/Ubiquity/controllers/crud/CRUDControllerUtilitiesTrait.php
@@ -187,7 +187,7 @@ trait CRUDControllerUtilitiesTrait {
 		return new ModelViewer ( $this );
 	}
 
-	public function _getModelViewer(): ModelViewer {
+	protected function _getModelViewer(): ModelViewer {
 		return $this->getSingleton ( $this->modelViewer, "getModelViewer" );
 	}
 


### PR DESCRIPTION
# Description

PHP version 7.4 gives fatal error on function _getModelViewer as it's declared 'abstract public' in MessagesTrait but implemented as 'protected' in CRUDControllerUtilitiesTrait

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
