### PR TITLE
fixed password_hash $algo type

### DIFF
--- a/src/Ubiquity/utils/http/URequest.php
+++ b/src/Ubiquity/utils/http/URequest.php
@@ -336,10 +336,10 @@ class URequest {
 	 * Creates a password hash for a posted value at $key position
 	 *
 	 * @param string $key
-	 * @param int $algo
+	 * @param string $algo
 	 * @return string|boolean
 	 */
-	public static function password_hash(string $key, int $algo = PASSWORD_DEFAULT) {
+	public static function password_hash(string $key, string $algo = PASSWORD_DEFAULT) {
 		if (isset ( $_POST [$key] )) {
 			return $_POST [$key] = password_hash ( $_POST [$key], $algo );
 		}


### PR DESCRIPTION
As of PHP 7.4, $algo is string. For example, PASSWORD_DEFAULT is '2y'.
For backward compatibility it accepts integer. For example, password_hash('1234', 0) returns PASSWORD_DEFAULT hash and password_hash('1234', 2) returns PASSWORD_ARGON2I hash.
When PASSWORD_DEFAULT('2y') is cast to integer, it is converted to 2, which is regarded as PASSWORD_ARGON2I.
cf. https://www.php.net/manual/en/function.password-hash.php#refsect1-function.password-hash-changelog