### PR TITLE
Added more logical error handling

### DIFF
--- a/src/Ubiquity/controllers/Startup.php
+++ b/src/Ubiquity/controllers/Startup.php
@@ -174,7 +174,14 @@ class Startup {
 						if (! \method_exists ( $controller, $action )) {
 							static::onError ( 404, "This action does not exist on the controller " . $ctrl, $controller );
 						} else {
-							Logger::warn ( 'Startup', $e->getTraceAsString (), 'runAction' );
+							$code = $e->getCode();
+							if ($code <= E_ERROR) {
+								Logger::critical('Startup', $e->getMessage(), 'runAction');
+							} elseif ($code <= E_WARNING) {
+								Logger::error('Startup', $e->getMessage(), 'runAction');
+							} else {
+								Logger::warn('Startup', $e->getMessage(), 'runAction');
+							}
 							if (self::$config ['debug']) {
 								throw $e;
 							} else {

--- a/src/Ubiquity/controllers/Startup.php
+++ b/src/Ubiquity/controllers/Startup.php
@@ -174,14 +174,7 @@ class Startup {
 						if (! \method_exists ( $controller, $action )) {
 							static::onError ( 404, "This action does not exist on the controller " . $ctrl, $controller );
 						} else {
-							$code = $e->getCode();
-							if ($code <= E_ERROR) {
-								Logger::critical('Startup', $e->getMessage(), 'runAction');
-							} elseif ($code <= E_WARNING) {
-								Logger::error('Startup', $e->getMessage(), 'runAction');
-							} else {
-								Logger::warn('Startup', $e->getMessage(), 'runAction');
-							}
+							static::logError($e->getCode(), $e->getMessage());
 							if (self::$config ['debug']) {
 								throw $e;
 							} else {
@@ -198,7 +191,7 @@ class Startup {
 				static::onError ( 404 ,"The controller `$ctrl` doesn't exist! <br/>");
 			}
 		} catch ( \Error $eC ) {
-			Logger::warn ( 'Startup', $eC->getTraceAsString (), 'runAction' );
+			static::logError($eC->getCode(), $eC->getMessage());
 			if (self::$config ['debug']) {
 				throw $eC;
 			} else {
@@ -278,6 +271,16 @@ class Startup {
 			}
 		});
 		$onError ( $code, $message, $controllerInstance );
+	}
+
+	public static function logError(int $code, string $message) {
+		if ($code <= E_ERROR) {
+			Logger::critical('Startup', $message, 'runAction');
+		} elseif ($code <= E_WARNING) {
+			Logger::error('Startup', $message, 'runAction');
+		} else {
+			Logger::warn('Startup', $message, 'runAction');
+		}
 	}
 
 	/**

--- a/src/Ubiquity/controllers/StartupAsync.php
+++ b/src/Ubiquity/controllers/StartupAsync.php
@@ -84,7 +84,7 @@ class StartupAsync extends Startup {
 						if (! \method_exists ( $controller, $action )) {
 							static::onError ( 404, "This action does not exist on the controller " . $ctrl, $controller );
 						} else {
-							Logger::warn ( 'Startup', $e->getTraceAsString (), 'runAction' );
+							static::logError($e->getCode(), $e->getMessage());
 							if (self::$config ['debug']) {
 								throw $e;
 							} else {
@@ -101,7 +101,7 @@ class StartupAsync extends Startup {
 				static::onError ( 404 );
 			}
 		} catch ( \Error $eC ) {
-			Logger::warn ( 'Startup', $eC->getTraceAsString (), 'runAction' );
+			static::logError($eC->getCode(), $eC->getMessage());
 			if (self::$config ['debug']) {
 				throw $eC;
 			} else {


### PR DESCRIPTION
# Description
For some reason, getTraceAsString is used as the error message. It is wrong. After all, we have to use getMessage

## Type of change
Bug fixes and bug-level categorization added

# How Has This Been Tested?
Make a critical error on the site and check the error
