### PR TITLE
Add Route status in getRoute method

### DIFF
--- a/src/Ubiquity/controllers/Router.php
+++ b/src/Ubiquity/controllers/Router.php
@@ -134,6 +134,7 @@ class Router {
 				}
 			}
 		}
+    self::$statusCode = RouterStatus::NOT_FOUND;
 		return false;
 	}
 


### PR DESCRIPTION
# Description

I faced the issue in my custom onError function. 
```
"onError" => function ($code, $message, $controllerInstance) {
    $statusCode = Router::getStatusCode();
    if ($statusCode !== $code) {
      $code = $statusCode;
      $message = null;
    }
    switch ($code) {
//Switch code.
    }
  }
```

I check the Router status with Router::getStatusCode(). In the case of 404 status, it generates an exception because getStatusCode() returns null (should return an int). That is because StatusCode wasn't set. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?